### PR TITLE
Trivial: Document how to run tests, ignore .pyc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.coverage
 /.pytest_cache
+*.pyc

--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ It needed a name,
 Kristian Glass built the initial version,
 it communicates with Philips monitors,
 and Philip Glass wrote Einstein on the Beach...
+
+## Running tests
+
+You can run the unittests with
+
+    make test


### PR DESCRIPTION
Unless you _want_ to see .pyc files in `git status` and I'm missing something....