### PR TITLE
Import from .common to avoid ambiguity

### DIFF
--- a/einstein/intellivue/association.py
+++ b/einstein/intellivue/association.py
@@ -1,6 +1,6 @@
 from scapy.all import *
 
-from common import *
+from .common import *
 
 """
 The LI field contains the length of the appended data (including all presentation data). The length


### PR DESCRIPTION
Especially given absolute/relative import changes with Python 3!