### PR TITLE
Remove tuple parameter unpacking

### DIFF
--- a/einstein/basic_dump.py
+++ b/einstein/basic_dump.py
@@ -5,7 +5,7 @@ import intellivue
 
 class SomnoDeviceDiscoveryDumper(DatagramProtocol):
 
-    def datagramReceived(self, data, (host, port)):
+    def datagramReceived(self, data, addr):
         ci = intellivue.ConnectIndication()
         ci.dissect(data)
         ci.show()


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-3113/

Twisted style is now `addr` not `(host, port)`