### PR TITLE
server/datagramReceived: fix undefined variable `port`

### DIFF
--- a/einstein/server.py
+++ b/einstein/server.py
@@ -50,6 +50,7 @@ class IntellivueInterface(DatagramProtocol):
     def datagramReceived(self, data, addr):
         log.debug("Datagram received!", addr=addr)
 
+        _, port = addr
         if port == packets.PORT_CONNECTION_INDICATION:
             self.handleConnectionIndication(data, addr)
         else:


### PR DESCRIPTION
We tried to export the data from Phillips FM20 (Fetal Monitor), but ran into an error about the undefined variable. 


----
Sponsored by: CMUH (China Medical University Hospital)